### PR TITLE
Single-line comments begin with `--`.

### DIFF
--- a/syntaxes/lbnf.tmLanguage.json
+++ b/syntaxes/lbnf.tmLanguage.json
@@ -19,7 +19,7 @@
 				},
 				{
 					"name": "comment.line.lbnf",
-					"match": "-.*"
+					"match": "--.*"
 				}
 			]
 		},


### PR DESCRIPTION
Thanks for this useful extension @agurodriguez.

I often get annoyed when I press Cmd-`/` and VSCode inserts only a single hyphen instead of two, this PR is to fix that problem.

See https://github.com/BNFC/bnfc/blob/master/docs/lbnf.rst#comments