### PR TITLE
Fix bug #2 - comments using "-" instead of "--"

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "-",
+        "lineComment": "--",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "{-", "-}" ]
     },


### PR DESCRIPTION
When merged, line comments will be correctly handled by comment/uncomment line command (Ctrl+/). Fixes #2.